### PR TITLE
Fixed verifyJarHook to hook using beforeHookedMethod

### DIFF
--- a/src/com/pyler/xinstaller/XInstaller.java
+++ b/src/com/pyler/xinstaller/XInstaller.java
@@ -245,7 +245,7 @@ public class XInstaller implements IXposedHookZygoteInit,
 		verifyJarHook = new XC_MethodHook() {
 			@SuppressWarnings("unchecked")
 			@Override
-			protected void afterHookedMethod(MethodHookParam param)
+			protected void beforeHookedMethod(MethodHookParam param)
 					throws Throwable {
 				prefs.reload();
 				verifyJar = prefs.getBoolean(PREF_DISABLE_VERIFY_JAR, false);


### PR DESCRIPTION
This should be the expected execution path. If the method is called an exception will be thrown, so afterHookedMethod is not appropriate
