### PR TITLE
Fixed "Showing buttons when obscured"

### DIFF
--- a/src/com/pyler/xinstaller/XInstaller.java
+++ b/src/com/pyler/xinstaller/XInstaller.java
@@ -1229,10 +1229,6 @@ public class XInstaller implements IXposedHookZygoteInit,
 					verifySignatureHook);
 
 			// 4.0 and newer
-			XposedBridge.hookAllMethods(View.class,
-					"onFilterTouchEventForSecurity", showButtonsHook);
-
-			// 4.0 and newer
 			XposedBridge.hookAllMethods(signatureClass, "verify",
 					verifySignatureHook);
 
@@ -1387,6 +1383,10 @@ public class XInstaller implements IXposedHookZygoteInit,
 			// 4.0 and newer
 			XposedHelpers.findAndHookMethod(Common.INSTALLAPPPROGRESS,
 					lpparam.classLoader, "initView", autoHideInstallHook);
+
+			// 4.0 and newer
+			XposedBridge.hookAllMethods(View.class,
+					"onFilterTouchEventForSecurity", showButtonsHook);
 		}
 
 		if (Common.SETTINGS_PKG.equals(lpparam.packageName)) {
@@ -1467,6 +1467,10 @@ public class XInstaller implements IXposedHookZygoteInit,
 			XposedHelpers.findAndHookMethod(Common.BACKUPRESTORECONFIRMATION,
 					lpparam.classLoader, "onCreate", Bundle.class,
 					autoBackupHook);
+
+			// 4.0 and newer
+			XposedBridge.hookAllMethods(View.class,
+					"onFilterTouchEventForSecurity", showButtonsHook);
 		}
 
 		if (Common.GOOGLEPLAY_PKG.equals(lpparam.packageName)) {


### PR DESCRIPTION
Unfortunately hook `onFilterTouchEventForSecurity` in the `android` package is not enough to enable the buttons when an overlay is displayed.

This commit enables the buttons that have the attribute `android:filterTouchesWhenObscured="true"` in the packages `com.android.packageinstaller` and `com.android.backupconfirm`.