### PR TITLE
squid:S1488 - squid:SwitchLastCaseIsDefaultCheck - Multiple quality i…

### DIFF
--- a/src/com/pyler/xinstaller/Preferences.java
+++ b/src/com/pyler/xinstaller/Preferences.java
@@ -155,11 +155,9 @@ public class Preferences extends PreferenceActivity
     }
 
     public boolean isEnabledInSettings() {
-        boolean isEnabledInSettings = PreferenceManager
+        return PreferenceManager
                 .getDefaultSharedPreferences(this).getBoolean(
                         Common.PREF_ENABLE_MODULE, true);
-
-        return isEnabledInSettings;
     }
 
     @Override
@@ -186,6 +184,8 @@ public class Preferences extends PreferenceActivity
                 break;
             case android.R.id.home:
                 onBackPressed();
+                break;
+            default:
                 break;
         }
         return super.onOptionsItemSelected(item);
@@ -423,6 +423,8 @@ public class Preferences extends PreferenceActivity
                         }
                     }
                 }
+                default:
+                    break;
             }
         }
 

--- a/src/com/pyler/xinstaller/XInstaller.java
+++ b/src/com/pyler/xinstaller/XInstaller.java
@@ -966,22 +966,19 @@ public class XInstaller implements IXposedHookZygoteInit,
 
     public boolean isModuleEnabled() {
         prefs.reload();
-        boolean enabled = prefs.getBoolean(Common.PREF_ENABLE_MODULE, true);
-        return enabled;
+        return prefs.getBoolean(Common.PREF_ENABLE_MODULE, true);
     }
 
     public boolean isExpertModeEnabled() {
         prefs.reload();
-        boolean enabled = prefs.getBoolean(Common.PREF_ENABLE_EXPERT_MODE,
+        return prefs.getBoolean(Common.PREF_ENABLE_EXPERT_MODE,
                 false);
-        return enabled;
     }
 
     public boolean changeDevicePropertiesEnabled() {
         prefs.reload();
-        boolean enabled = prefs.getBoolean(
+        return prefs.getBoolean(
                 Common.PREF_ENABLE_CHANGE_DEVICE_PROPERTIES, false);
-        return enabled;
     }
 
     public void changeDeviceProperties() {

--- a/src/com/pyler/xinstaller/legacy/XInstaller.java
+++ b/src/com/pyler/xinstaller/legacy/XInstaller.java
@@ -1494,22 +1494,19 @@ public class XInstaller implements IXposedHookZygoteInit,
 
 	public boolean isModuleEnabled() {
 		prefs.reload();
-		boolean enabled = prefs.getBoolean(Common.PREF_ENABLE_MODULE, true);
-		return enabled;
+		return prefs.getBoolean(Common.PREF_ENABLE_MODULE, true);
 	}
 
 	public boolean isExpertModeEnabled() {
 		prefs.reload();
-		boolean enabled = prefs.getBoolean(Common.PREF_ENABLE_EXPERT_MODE,
+		return prefs.getBoolean(Common.PREF_ENABLE_EXPERT_MODE,
 				false);
-		return enabled;
 	}
 
 	public boolean changeDevicePropertiesEnabled() {
 		prefs.reload();
-		boolean enabled = prefs.getBoolean(
+		return prefs.getBoolean(
 				Common.PREF_ENABLE_CHANGE_DEVICE_PROPERTIES, false);
-		return enabled;
 	}
 
 	public void changeDeviceProperties() {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules squid:S1488 - Local Variables should not be declared and then immediately returned or thrown
squid:SwitchLastCaseIsDefaultCheck - "switch" statements should end with a "default" clause


You can find more information about the issues here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1488
https://dev.eclipse.org/sonar/coding_rules#q=squid:SwitchLastCaseIsDefaultCheck

Please let me know if you have any questions.

M-Ezzat