### PR TITLE
Cleanup - squid:S1488 - Local Variables should not be declared and th…

### DIFF
--- a/src/com/pyler/xinstaller/Preferences.java
+++ b/src/com/pyler/xinstaller/Preferences.java
@@ -155,11 +155,9 @@ public class Preferences extends PreferenceActivity
     }
 
     public boolean isEnabledInSettings() {
-        boolean isEnabledInSettings = PreferenceManager
+        return PreferenceManager
                 .getDefaultSharedPreferences(this).getBoolean(
                         Common.PREF_ENABLE_MODULE, true);
-
-        return isEnabledInSettings;
     }
 
     @Override

--- a/src/com/pyler/xinstaller/XInstaller.java
+++ b/src/com/pyler/xinstaller/XInstaller.java
@@ -964,22 +964,19 @@ public class XInstaller implements IXposedHookZygoteInit,
 
     public boolean isModuleEnabled() {
         prefs.reload();
-        boolean enabled = prefs.getBoolean(Common.PREF_ENABLE_MODULE, true);
-        return enabled;
+        return prefs.getBoolean(Common.PREF_ENABLE_MODULE, true);
     }
 
     public boolean isExpertModeEnabled() {
         prefs.reload();
-        boolean enabled = prefs.getBoolean(Common.PREF_ENABLE_EXPERT_MODE,
+        return prefs.getBoolean(Common.PREF_ENABLE_EXPERT_MODE,
                 false);
-        return enabled;
     }
 
     public boolean changeDevicePropertiesEnabled() {
         prefs.reload();
-        boolean enabled = prefs.getBoolean(
+        return prefs.getBoolean(
                 Common.PREF_ENABLE_CHANGE_DEVICE_PROPERTIES, false);
-        return enabled;
     }
 
     public void changeDeviceProperties() {

--- a/src/com/pyler/xinstaller/legacy/XInstaller.java
+++ b/src/com/pyler/xinstaller/legacy/XInstaller.java
@@ -1494,22 +1494,19 @@ public class XInstaller implements IXposedHookZygoteInit,
 
 	public boolean isModuleEnabled() {
 		prefs.reload();
-		boolean enabled = prefs.getBoolean(Common.PREF_ENABLE_MODULE, true);
-		return enabled;
+		return prefs.getBoolean(Common.PREF_ENABLE_MODULE, true);
 	}
 
 	public boolean isExpertModeEnabled() {
 		prefs.reload();
-		boolean enabled = prefs.getBoolean(Common.PREF_ENABLE_EXPERT_MODE,
+		return prefs.getBoolean(Common.PREF_ENABLE_EXPERT_MODE,
 				false);
-		return enabled;
 	}
 
 	public boolean changeDevicePropertiesEnabled() {
 		prefs.reload();
-		boolean enabled = prefs.getBoolean(
+		return prefs.getBoolean(
 				Common.PREF_ENABLE_CHANGE_DEVICE_PROPERTIES, false);
-		return enabled;
 	}
 
 	public void changeDeviceProperties() {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1488 - Local Variables should not be declared and then immediately returned or thrown

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1488

Please let me know if you have any questions.

M-Ezzat